### PR TITLE
feat: add extism build script util

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,14 +26,11 @@ zig fetch --save https://github.com/extism/zig-sdk/archive/<git-ref-here>.tar.gz
 
 And in your `build.zig`:
 ```zig
-const extism_module = b.dependency("extism", .{ .target = target, .optimize = optimize }).module("extism");
-exe.root_module.addImport("extism", extism_module);
-// TODO: make this easier to install
-// add the shared library & header
-exe.linkLibC();
-exe.addIncludePath(.{ .path = "/usr/local/include" });
-exe.addLibraryPath(.{ .path = "/usr/local/lib" });
-exe.linkSystemLibrary("extism");
+// to use the build script util, import extism:
+const extism = @import("extism");
+
+// inside your `build` function, after you've created tests or an executable step:
+extism.addLibrary(exe, b);
 ```
 
 ## Getting Started

--- a/build.zig
+++ b/build.zig
@@ -51,3 +51,12 @@ pub fn build(b: *std.Build) void {
     const example_step = b.step("run_example", "Run the basic example");
     example_step.dependOn(&example_run_step.step);
 }
+
+pub fn addLibrary(to: *std.Build.Step.Compile, b: *std.Build) void {
+    to.root_module.addImport("extism", b.dependency("extism", .{}).module("extism"));
+    to.linkLibC();
+    // TODO: switch based on platform and use platform-specific paths here
+    to.addIncludePath(.{ .path = "/usr/local/include" });
+    to.addLibraryPath(.{ .path = "/usr/local/lib" });
+    to.linkSystemLibrary("extism");
+}


### PR DESCRIPTION
This makes it simpler to start using extism by hiding some of the linking steps. It assumes that the shared library has been installed already and into the well-known paths. 

It's possible to automate the installation of that as well, but I think there's maybe too much magic using our existing CLI installer.. perhaps at some point in the future we could have a `zig build` of `libextism` which clones the Rust source, builds it using `cargo` as a subprocess, and locates & installs the shared lib and header accordingly. I don't know if that's the right approach, but my point is we can probably do more than just what I have here :) 